### PR TITLE
Adds option to disable malloc replacement

### DIFF
--- a/src/msource/CMakeLists.txt
+++ b/src/msource/CMakeLists.txt
@@ -1,6 +1,8 @@
 
+set(PGASUS_REPLACE_MALLOC ON CACHE BOOL
+	"Determines whether PGASUS replaces the process-wide malloc function.")
+
 set(PUBLIC_HEADERS
-	${PROJECT_INCLUDE_DIR}/PGASUS/malloc.hpp
 	${PROJECT_INCLUDE_DIR}/PGASUS/msource/mmaphelper.h
 	${PROJECT_INCLUDE_DIR}/PGASUS/msource/msource.hpp
 	${PROJECT_INCLUDE_DIR}/PGASUS/msource/msource_allocator.hpp
@@ -9,12 +11,25 @@ set(PUBLIC_HEADERS
 	${PROJECT_INCLUDE_DIR}/PGASUS/msource/singleton.hpp
 )
 
+if(PGASUS_REPLACE_MALLOC)
+	set(PUBLIC_HEADERS 
+		${PUBLIC_HEADERS}
+		${PROJECT_INCLUDE_DIR}/PGASUS/malloc.hpp
+	)
+endif()
+
 set(SOURCES
 	${PUBLIC_HEADERS}
 	mmaphelper.cpp
 	msource.cpp
-	stackedmalloc.cpp
 )
+
+if(PGASUS_REPLACE_MALLOC)
+	set(SOURCES 
+		${SOURCES}
+		stackedmalloc.cpp
+	)
+endif()
 
 set(include_dirs
 	PRIVATE


### PR DESCRIPTION
This PR adds an option `PGASUS_REPLACE_MALLOC` to replace the process-wide `malloc` replacement of PGASUS. This is enabled by default, but can be disabled by applications.