### PR TITLE
Move ZLIB dependency to tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ endif()
 add_PGASUS_option(WITH_TASKING
 	"Include tasking support, currently requiring boost version >= 1.58 and <= 1.60." ON)
 
+add_PGASUS_option(WITH_TESTS
+	"Compile tests for PGASUS." ON)
+
 
 if (NOT DEFAULT_COMPILE_DEFINITIONS)
 	set(DEFAULT_COMPILE_DEFINITIONS)
@@ -177,7 +180,6 @@ if (PGASUS_WITH_TASKING)
 Disable tasking support to omit the Boost dependency (See PGASUS_WITH_TASKING).")
 	endif()
 endif()
-find_package(ZLIB REQUIRED)
 find_package(NUMA REQUIRED)
 find_package(HWLOC REQUIRED)
 find_package(Sanitizers QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,19 @@ if (NOT PGASUS_MMAP_THRESHOLD GREATER -1)
 Current value: ${PGASUS_MMAP_THRESHOLD}")
 endif()
 
+set(PGASUS_REPLACE_MALLOC ON CACHE BOOL
+	"Determines whether PGASUS replaces the process-wide malloc function.")
+
 add_PGASUS_option(WITH_TASKING
 	"Include tasking support, currently requiring boost version >= 1.58 and <= 1.60." ON)
 
-add_PGASUS_option(WITH_TESTS
-	"Compile tests for PGASUS." ON)
+add_PGASUS_option(BUILD_TESTS "Build the tests and benchmarks (requires further 3rd party libs)." ON)
+
+add_PGASUS_option(TEST_WITH_FAKE_TOPOLOGY
+	"Simulate POWER-like virtualized topology by overriding some hwloc functions." OFF)
+mark_as_advanced(PGASUS_TEST_WITH_FAKE_TOPOLOGY)
+
+add_PGASUS_option(BUILD_DOCUMENTATION "Build the source documentation (requires doxygen)." ON)
 
 
 if (NOT DEFAULT_COMPILE_DEFINITIONS)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,7 +1,3 @@
-
-option(PGASUS_BUILD_DOCUMENTATION "Build the source documentation (requires doxygen)." ON)
-mark_as_advanced(PGASUS_BUILD_DOCUMENTATION)
-
 if (NOT PGASUS_BUILD_DOCUMENTATION)
     return()
 endif()

--- a/src/msource/CMakeLists.txt
+++ b/src/msource/CMakeLists.txt
@@ -1,7 +1,4 @@
 
-set(PGASUS_REPLACE_MALLOC ON CACHE BOOL
-	"Determines whether PGASUS replaces the process-wide malloc function.")
-
 set(PUBLIC_HEADERS
 	${PROJECT_INCLUDE_DIR}/PGASUS/msource/mmaphelper.h
 	${PROJECT_INCLUDE_DIR}/PGASUS/msource/msource.hpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,14 +1,8 @@
 
-option(PGASUS_BUILD_TESTS "Build the tests and benchmarks (requires further 3rd party libs)." ON)
-mark_as_advanced(PGASUS_BUILD_TESTS)
-
 if (NOT PGASUS_BUILD_TESTS)
 	return()
 endif()
 
-option(PGASUS_TEST_WITH_FAKE_TOPOLOGY
-	"Simulate POWER-like virtualized topology by overriding some hwloc functions." OFF)
-mark_as_advanced(PGASUS_TEST_WITH_FAKE_TOPOLOGY)
 if (PGASUS_TEST_WITH_FAKE_TOPOLOGY)
 	if (NOT PGASUS_BUILD_STATIC_LIBRARIES)
 		message(WARNING "PGASUS_TEST_WITH_FAKE_TOPOLOGY requires PGASUS_BUILD_STATIC_LIBRARIES to be set.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,8 @@ if (PGASUS_TEST_WITH_FAKE_TOPOLOGY)
 	endif()
 endif()
 
+find_package(ZLIB REQUIRED)
+
 function(replace_by_static_libs LINK_LIST)
 	set(result)
 	set(target_libs hpinuma_util hpinuma_msource hpinuma)


### PR DESCRIPTION
In Hyrise we only use the `MemSource` component of PGASUS. Afaik zlib is only required for the tests. Imo it doesn't make sense to have it in the root `CMakeLists.txt`